### PR TITLE
Chat Component Rendering of Messages

### DIFF
--- a/components/Chat.js
+++ b/components/Chat.js
@@ -1,41 +1,26 @@
-import React from 'react'
+import React, { Component } from 'react'
 import _ from 'lodash'
-import $ from 'jquery'
 import CommentBar from './CommentBar'
 
-export default class Chat extends React.Component {
+export default class Chat extends Component {
   constructor(props) {
     super(props)
   }
-  __createMessagesList() {
-    const data = this.props.data
-    console.log('CHAT PAGE ', data)
 
-    let sortedMessages = _.sortBy(data, 'timestamp');
-
-    _.forEach(sortedMessages, (value, key) => {
-      const message = value.message
-
-      $('#chatMessageList').append(
-        $('<div>')
-        .append($('</div>'))
-        .addClass("chat__message")
-        .append("<span/>")
-        .text(message)
-      );
-    })
-  }
-
-  componentDidMount() {
-
-  }
   render() {
-    // @TODO - Messages are duplicating because render() keeps firing everytime state get's updated (i.e messages are added to firebase)
-    // I need to move __createMEssageList() out of render() but I am not sure where... I need to learn how to update state properly
-    this.__createMessagesList()
+    const { data } = this.props;
+    const sortedMessages = _.sortBy(data, 'timestamp');
+    const messageHtml = sortedMessages.map((value, i) => (
+      <div className="chat__message" key={i}>
+        <span>{value.message}</span>
+      </div>
+    ));
+    
     return (
       <div className="chat-ui">
-        <div id="chatMessageList"></div>
+        <div id="chatMessageList">
+          {messageHtml}
+        </div>
           <CommentBar channelName={this.props.channelName}/>
       </div>
     )

--- a/pages/channel.js
+++ b/pages/channel.js
@@ -11,6 +11,10 @@ class Channel extends React.Component {
     super(props)
     this.state = {data: {}};
   }
+  /** 
+   * Might want to get rid of componentWillMount here
+   * Source: https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html
+   * **/
   componentWillMount() {
     const key = this.props.url.query.name
 


### PR DESCRIPTION
@OneHunnid Figured this was probably the easiest way to do it so you could easily see the diff. Don't really care if you close or merge the PR.

Wasn't able to reproduce the issue very consistently...so unsure if this will fully fix it. First I tried to pull `createMessagesList` into a lifecycle method, but it broke because jQuery creation of dom elements doesn't seem to register unless it's directly called in react's `render`. 

Decided to just strip out the jQuery in this component and let react handle the creation of the dom elements instead. Wasn't able to replicate the issue after the fact, but was also having troubles reproducing the issue consistently prior.

I didn't do this, but if that solution does work...could probably also make this a stateless component as well to simplify things a bit.

Anyway hope this helps. 